### PR TITLE
Updating Commander Dispose to just kill the process. 

### DIFF
--- a/Domino/Commander.cs
+++ b/Domino/Commander.cs
@@ -72,12 +72,9 @@ namespace domino
         {
             if (_process != null)
             {
-                if (!_process.HasExited)
-                {
-                    _process.Kill();
-                    _cancellationTokenSource.Cancel();
-                    _cancellationTokenSource.Dispose();
-                }
+                _process.Kill();
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Dispose();
                 _process.Dispose();
             }
         }

--- a/Domino/domino.csproj
+++ b/Domino/domino.csproj
@@ -9,13 +9,13 @@
     <PackageProjectUrl>https://github.com/DillonAd/Domino</PackageProjectUrl>
     <RepositoryUrl>https://github.com/DillonAd/Domino</RepositoryUrl>
     <PackageTags>File Watcher</PackageTags>
-    <VersionPrefix>0.0.6</VersionPrefix>
+    <VersionPrefix>0.0.7</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseUrl>https://github.com/DillonAd/Domino/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/DillonAd/Domino/master/domino.png</PackageIconUrl>
-    <AssemblyVersion>0.0.6.0</AssemblyVersion>
-    <FileVersion>0.0.6.0</FileVersion>
-    <Version>0.0.6</Version>
+    <AssemblyVersion>0.0.7.0</AssemblyVersion>
+    <FileVersion>0.0.7.0</FileVersion>
+    <Version>0.0.7</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,8 @@ stages:
   - stage: Build
     jobs:
       - job: Build
+        workspace:
+          clean: all
         pool: Default
         variables:
             buildConfiguration: 'Release'


### PR DESCRIPTION
Since Windows throws an error when checking the state of the process when getting the `HasExited` propery on the `Process` object, this removes that check.